### PR TITLE
feat: documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Description of configuration parameters:
 | Documentation Repository Base Dir. | Name of the folder containing the documentation source. |
 | Documentation Repository Request Timeout In Seconds | Time limit to download a single documentation file. |
 | Documentation Repository Supported Extensions | Name of supported file extensions (currently only Markdown files). |
-| Chain RAG System Prompts File Path | ath to the file containing system prompts for the RAG model. |
-| Chain RAG User Prompts File Path | Path to the file containing user prompts for the RAG model.
+| Chain RAG System Prompts File Path | Path to the file containing system prompts for the RAG model. |
+| Chain RAG User Prompts File Path | Path to the file containing user prompts for the RAG model. |
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -14,152 +14,7 @@ This repository contains the backend code, which consists of a web server that p
 
 The backend was developed using the [LangChain](https://python.langchain.com/docs/get_started/introduction/) framework, which enables creating sequences of complex interactions using Large Language Models. The web server was implemented using the [FastAPI](https://fastapi.tiangolo.com/) framework.
 
-## Main Features
-
-### Chat Endpoint (`/chat/completions`)
-
-The `/chat/completions` endpoint generates responses to user queries based on provided context and chat history. It leverages information from the configured Vector Store to formulate relevant responses, enhancing the conversational experience.
-
-***Eg***:
-
-<details>
-<summary>Request</summary>
-
-```curl
-curl 'http://localhost:3000/chat/completions' \
-  -H 'content-type: application/json' \
-  --data-raw '{"chat_query":"Design a CRUD schema for an online store selling merchandise items","chat_history":[]}'
-```
-
-</details>
-
-<details>
-<summary>Response</summary>
-
-```json
-{
-    "message": "For an online store selling merchandise items, we can design a CRUD schema for a `Product` entity with the following properties:\n\n- `name`: A mandatory string.\n- `description`: An optional string.\n- `price`: A mandatory number.\n\nThe CRUD schema, excluding the default attributes, would look like this:\n\n```json\n[\n  {\n    \"name\": \"name\",\n    \"type\": \"string\",\n    \"required\": true,\n    \"nullable\": false,\n    \"encryptionEnabled\": false,\n    \"encryptionSearchable\": false,\n    \"sensitivityValue\": 0\n  },\n  {\n    \"name\": \"price\",\n    \"type\": \"number\",\n    \"required\": true,\n    \"nullable\": false,\n    \"encryptionEnabled\": false,\n    \"encryptionSearchable\": false,\n    \"sensitivityValue\": 0\n  },\n  {\n    \"name\": \"description\",\n    \"type\": \"string\",\n    \"required\": false,\n    \"nullable\": false,\n    \"encryptionEnabled\": false,\n    \"encryptionSearchable\": false,\n    \"sensitivityValue\": 0\n  }\n]\n```\n\nThis schema defines the structure of the `Product` entity with the necessary properties for managing merchandise items in the online store.",
-    "references": [
-        {
-            "content": "### Create CRUD to Read and Write Table Data  \nTo evaluate the new page, it's essential to create a CRUD microservice and expose the relevant data through an endpoint, facilitating reading and writing operations on our table.  \n:::warning\nIf you're unfamiliar with CRUD microservices, consider consulting the [CRUD Tutorial](/console/tutorials/configure-marketplace-components/rest-api-for-crud-on-data.mdx).\n:::  \nFor our example, let's employ a basic CRUD microservice featuring a `Product` entity endowed with the subsequent properties:\n* `name`: A mandatory string.\n* `description`: An optional string.\n* `price`: A mandatory number.  \nThe data CRUD will be exposed via an endpoint named `products`.  \nBelow is the CRUD schema, excluding the default CRUD attributes (_id, creatorId, createdAt, updaterId, updatedAt, and \\_\\_STATE\\_\\_):  \n```json\n[\n{\n\"name\":\"name\",\n\"type\":\"string\",\n\"required\":true,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n},\n{\n\"name\":\"price\",\n\"type\":\"number\",\n\"required\":true,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n},\n{\n\"name\":\"description\",\n\"type\":\"string\",\n\"required\":false,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n}\n]\n```\nNow, the CRUD data can be exposed using an endpoint named `products`.",
-            "url": "https://docs.mia-platform.eu/docs/microfrontend-composer/tutorials/basics"
-        },
-        {
-            "content": "### Create CRUD to Read and Write Table Data  \nTo evaluate the new page, it's essential to create a CRUD microservice and expose the relevant data through an endpoint, facilitating reading and writing operations on our table.  \n:::warning\nIf you're unfamiliar with CRUD microservices, consider consulting the [CRUD Tutorial](/console/tutorials/configure-marketplace-components/rest-api-for-crud-on-data.mdx).\n:::  \nFor our example, let's employ a basic CRUD microservice featuring a `Product` entity endowed with the subsequent properties:\n* `name`: A mandatory string.\n* `description`: An optional string.\n* `price`: A mandatory number.  \nThe data CRUD will be exposed via an endpoint named `products`.  \nBelow is the CRUD schema, excluding the default CRUD attributes (_id, creatorId, createdAt, updaterId, updatedAt, and \\_\\_STATE\\_\\_):  \n```json\n[\n{\n\"name\":\"name\",\n\"type\":\"string\",\n\"required\":true,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n},\n{\n\"name\":\"price\",\n\"type\":\"number\",\n\"required\":true,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n},\n{\n\"name\":\"description\",\n\"type\":\"string\",\n\"required\":false,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n}\n]\n```\nNow, the CRUD data can be exposed using an endpoint named `products`.",
-            "url": "https://docs.mia-platform.eu/docs/microfrontend-composer/tutorials/basics"
-        },
-        {
-            "content": "### Create a CRUD for persistency  \nTo create a CRUD service you can follow [this](/console/tutorials/configure-marketplace-components/rest-api-for-crud-on-data.mdx) tutorial.\nAs data schema please import this <a download target=\"_blank\" href=\"/docs_files_to_download/flow-manager-service/saga-collection.json\">schema</a>.  \nRemember to create a **unique index** for the collection on the `sagaId` field and to set the **default state** for new documents to `PUBLIC`.  \nTo do this follow these steps:\n1. Open the _Design_ section of the Console.\n1. On the left panel, in the _Data Models_ group, click on _MongoDB CRUD_ section.\n1. Click on the CRUD you created.\n1. In the _Indexes_ section click _Add index_.\n1. Enter these values:\n- **Name**: `sagaIdIndex`\n- **Type**: `Normal`\n- **Field**: `sagaId`  \n<div style={{display: 'flex', justifyContent: 'center'}}>\n<div style={{display: 'flex', width: '600px'}}>  \n![Create CRUD index](img/create-crud-1.png)  \n</div>\n</div>  \n1. Click _Create_. The new index will be shown.\n1. Set the `unique` checkbox for the `sagaIdIndex` index.\n1. In the _Internal Endpoints_ section make sure that `Default state` is set to `PUBLIC`.  \n<div style={{display: 'flex', justifyContent: 'center'}}>\n<div style={{display: 'flex', width: '600px'}}>  \n![Create CRUD index](img/create-crud-2.png)  \n</div>\n</div>  \nYou can find more information on CRUD Persistency Manager in the [dedicated](/runtime_suite/flow-manager-service/30_configuration.md#crud-persistency-manager) page.",
-            "url": "https://docs.mia-platform.eu/docs/console/tutorials/configure-marketplace-components/flow-manager"
-        },
-        {
-            "content": "### Create a CRUD for persistency  \nTo create a CRUD service you can follow [this](/console/tutorials/configure-marketplace-components/rest-api-for-crud-on-data.mdx) tutorial.\nAs data schema please import this <a download target=\"_blank\" href=\"/docs_files_to_download/flow-manager-service/saga-collection.json\">schema</a>.  \nRemember to create a **unique index** for the collection on the `sagaId` field and to set the **default state** for new documents to `PUBLIC`.  \nTo do this follow these steps:\n1. Open the _Design_ section of the Console.\n1. On the left panel, in the _Data Models_ group, click on _MongoDB CRUD_ section.\n1. Click on the CRUD you created.\n1. In the _Indexes_ section click _Add index_.\n1. Enter these values:\n- **Name**: `sagaIdIndex`\n- **Type**: `Normal`\n- **Field**: `sagaId`  \n<div style={{display: 'flex', justifyContent: 'center'}}>\n<div style={{display: 'flex', width: '600px'}}>  \n![Create CRUD index](img/create-crud-1.png)  \n</div>\n</div>  \n1. Click _Create_. The new index will be shown.\n1. Set the `unique` checkbox for the `sagaIdIndex` index.\n1. In the _Internal Endpoints_ section make sure that `Default state` is set to `PUBLIC`.  \n<div style={{display: 'flex', justifyContent: 'center'}}>\n<div style={{display: 'flex', width: '600px'}}>  \n![Create CRUD index](img/create-crud-2.png)  \n</div>\n</div>  \nYou can find more information on CRUD Persistency Manager in the [dedicated](/runtime_suite/flow-manager-service/30_configuration.md#crud-persistency-manager) page.",
-            "url": "https://docs.mia-platform.eu/docs/console/tutorials/configure-marketplace-components/flow-manager"
-        }
-    ]
-}
-```
-
-</details>
-
-### Metrics Endpoint (`/-/metrics`)
-
-The `/-/metrics` endpoint exposes the metrics collected by Prometheus.
-
-## High Level Architecture
-
-The following is the high-level architecture of ai-rag-template.
-
-```mermaid
-flowchart LR
-  fe[Frontend]
-  be[Backend]
-  vs[(Vector Store)]
-  llm[LLM API]
-  eg[Embeddings Generator API]
-
-  fe --1. user question +\nchat history--> be
-  be --2. user question--> eg
-  eg --3. embedding-->be
-  be --4. similarity search-->vs
-  vs --5. similar docs-->be
-  be --6. user question +\nchat history +\nsimilar docs-->llm
-  llm --7. bot answer--> be
-  be --8. bot answer--> fe
-```
-
-## Configuration
-
-The service requires several configuration parameters for execution. Below is an example configuration:
-
-```json
-{
-  "llm": {
-    "name": "gpt-3.5-turbo"
-  },
-  "embeddings": {
-    "name": "text-embedding-3-small"
-  },
-  "vectorStore": {
-    "dbName": "database-test",
-    "collectionName": "assistant-documents",
-    "indexName": "vector_index",
-    "relevanceScoreFn": "euclidean",
-    "embeddingKey": "embedding",
-    "textKey": "text",
-    "maxDocumentsToRetrieve": 4,
-    "minScoreDistance": 0.5
-  },
-  "documentation": {
-    "repository": {
-      "baseUrl": "https://api.github.com/repos",
-      "owner": "/mia-platform",
-      "name": "/documentation",
-      "baseDir": "docs",
-      "supportedExtensions": [
-        ".md",
-        ".mdx"
-      ],
-      "requestTimeoutInSeconds": 30
-    },
-    "website": {
-      "baseUrl": "https://docs.mia-platform.eu"
-    }
-  },
-  "chain": {
-    "aggregateMaxTokenNumber": 2000,
-    "rag": {
-      "promptsFilePath": {
-        "system": "/path/to/system-prompt.txt",
-        "user": "/path/to/user-prompt.txt"
-      }
-    }
-  }
-}
-```
-
-Description of configuration parameters:
-
-| Param Name | Description |
-|------------|-------------|
-| LLM Name | Name of the chat model to use. [Must be supported by LangChain.](https://python.langchain.com/docs/integrations/chat/) |
-| Embeddings Name | Name of the encoder to use. [Must be supported by LangChain.](https://python.langchain.com/docs/integrations/text_embedding/) |
-| Vector Store DB Name | Name of the MongoDB database to use as a knowledge base. |
-| Vector Store Collection Name | Name of the MongoDB collection to use for storing documents and document embeddings. |
-| Vector Store Index Name | Name of the vector index to use for retrieving documents related to the user's query. **Note:** [Currently, it's necessary to manually create this index on MongoDB Atlas.](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/) |
-| Vector Store Relevance Score Function | Name of the similarity function used for extracting similar documents using the created vector index. **Note:** Must be the same used to create the vector index. |
-| Vector Store Embeddings Key | Name of the field used to save the semantic encoding of documents. |
-| Vector Store Text Key | Name of the field used to save the raw document (or chunk of document). |
-| Vector Store Max. Documents To Retrieve | Maximum number of documents to retrieve from the Vector Store. |
-| Vector Store Min. Score Distance | Minimum distance beyond which retrieved documents from the Vector Store are discarded. |
-| Documentation Repository Base Url | Base path of the GitHub repository to download documentation from. |
-| Documentation Repository Owner | Owner name of the documentation repository. |
-| Documentation Repository Name | Name of the documentation repository. |
-| Documentation Repository Base Dir. | Name of the folder containing the documentation source. |
-| Documentation Repository Request Timeout In Seconds | Time limit to download a single documentation file. |
-| Documentation Repository Supported Extensions | Name of supported file extensions (currently only Markdown files). |
-| Chain RAG System Prompts File Path | Path to the file containing system prompts for the RAG model. |
-| Chain RAG User Prompts File Path | Path to the file containing user prompts for the RAG model. |
+More information on how the service works can be found in the [Overview and Usage](./docs/10_Overview_And_Usage.md) page.
 
 ## Local Development
 
@@ -173,14 +28,14 @@ Description of configuration parameters:
 cp default.env local.env
 ```
 
-- Modify the values of the environment variables in the newly created file
+- Modify the values of the environment variables in the newly created file (for more info, refer to the [Overview and Usage](./docs/10_Overview_And_Usage.md#environment-variables) page)
 - Create a configuration file located in the path defined as the `CONFIGURATION_PATH` value in the environment variables file. As example, you can copy the `default.configuration.json` file into a new file called `local.configuration.json` with the following command:
 
 ```sh
 cp default.configuration.json local.configuration.json
 ```
 
-- Modify the values of the configuration in the newly created file, accordingly to the definitions included in the [Configuration paragraph](#configuration)
+- Modify the values of the configuration in the newly created file, accordingly to the definitions included in the [Overview and Usage](./docs/10_Overview_And_Usage.md#configuration) page.
 
 ### Startup
 

--- a/docs/10_Overview_And_Usage.md
+++ b/docs/10_Overview_And_Usage.md
@@ -1,0 +1,96 @@
+# ai-rag-template
+
+The `ai-rag-template` is a template to build and run your own RAG application to have a Chatbot that is capable to perform a conversation with the user.
+
+<!-- TODO: We use OpenAI, Langchain, MongoDB -->
+
+## Environment Variables
+
+The following environment variables are required for the service to work:
+
+- **PORT**: the port used to expose the API (default: *3000*)
+- **LOG_LEVEL**: the level of the logger (default: *INFO*)
+- **CONFIGURATION_PATH**: the path that contains the [JSON configuration file](#configuration)
+- **MONGODB_CLUSTER_URI**: the MongoDB connectio string
+- **LLM_API_KEY**: the API Key of the LLM (*NOTE*: currently, we support only the OpenAI models, thus the API Key is the same as the OpenAI API Key)
+- **EMBEDDINGS_API_KEY**: the API Key of the embeddings model (*NOTE*: currently, we support only the OpenAI models, thus the API Key is the same as the OpenAI API Key)
+
+It is suggested to save the environment variables in a `.env` file.
+
+## Configuration
+
+The service requires several configuration parameters for execution. Below is an example configuration:
+
+```json
+{
+  "llm": {
+    "name": "gpt-3.5-turbo"
+  },
+  "embeddings": {
+    "name": "text-embedding-3-small"
+  },
+  "vectorStore": {
+    "dbName": "database-test",
+    "collectionName": "assistant-documents",
+    "indexName": "vector_index",
+    "relevanceScoreFn": "euclidean",
+    "embeddingKey": "embedding",
+    "textKey": "text",
+    "maxDocumentsToRetrieve": 4,
+    "minScoreDistance": 0.5
+  },
+  "chain": {
+    "aggregateMaxTokenNumber": 2000,
+    "rag": {
+      "promptsFilePath": {
+        "system": "/path/to/system-prompt.txt",
+        "user": "/path/to/user-prompt.txt"
+      }
+    }
+  }
+}
+```
+
+Description of configuration parameters:
+
+| Name | Key | Description |
+|------|-----|-------------|
+| LLM Name | `llm.name` | Name of the chat model to use. We currently support only [OpenAI models](https://platform.openai.com/docs/models). |
+| Embeddings Name | `embeddings.name` | Name of the encoder to use. We currently support only [OpenAI embeddings models](https://platform.openai.com/docs/guides/embeddings/what-are-embeddings). |
+| Vector Store DB Name | `vectorStore.dbName` | Name of the MongoDB database to use as a knowledge base and that contains the collection with the embeddings. |
+| Vector Store Collection Name | `vectorStore.collectionName` | Name of the MongoDB collection to use for storing documents and document embeddings. |
+| Vector Store Index Name | `vectorStore.indexName` | Name of the vector index to use for retrieving documents related to the user's query. **Note:** [Currently, it's necessary to manually create this index on MongoDB Atlas.](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/) |
+| Vector Store Relevance Score Function | `vectorStore.relevanceScoreFn` | Name of the similarity function used for extracting similar documents using the created vector index. **Note:** Must be the same used to create the vector index. |
+| Vector Store Embeddings Key | `vectorStore.embeddingsKey` | Name of the field used to save the semantic encoding of documents. The question received will be compared to the vector in this field with the Vector Index. |
+| Vector Store Text Key | `vectorStore.textKey` | Name of the field used to save the raw document (or chunk of document). The content of this field will be included in the prompt. |
+| Vector Store Max. Documents To Retrieve | `vectorStore.maxDocumentsToRetrieve` | Maximum number of documents retrieved from the Vector Store. |
+| Vector Store Min. Score Distance | `vectorStore.minScoreDistance` | Minimum score required for the extracted document to be used in the prompt. Any document with a score below this value will be discarded. |
+| Chain RAG System Prompts File Path | `vectorStore.textKey` | Path to the file containing system prompts for the RAG model. |
+| Chain RAG User Prompts File Path | `vectorStore.textKey` | Path to the file containing user prompts for the RAG model. |
+
+### Create a Vector Index
+
+This template requires a [MongoDB Vector Search Index](https://www.mongodb.com/docs/atlas/atlas-vector-search/tutorials/vector-search-quick-start/) to function correctly, and requires a MongoDB Atlas instance version 6 or above to work.
+
+You can create a new Vector Search Index with the following structure:
+
+```json
+{
+    "fields": [
+        {
+            "type": "vector",
+            "path": "<<embeddingsKey>>",
+            "numDimensions": 768,
+            "similarity": "<<relevanceScoreFn>>"
+        }
+    ]
+}
+```
+
+You should remember to:
+
+- to have as `path` the same value of the `vectorStore.embeddingsKey` configuration parameter
+- to have as `similarity` the same value of the `vectorStore.relevanceScoreFn` configuration parameter
+- to have as `numDimensions` to appropriate value based on the [embeddings model used](https://platform.openai.com/docs/guides/embeddings/how-to-get-embeddings)
+
+## API

--- a/docs/10_Overview_And_Usage.md
+++ b/docs/10_Overview_And_Usage.md
@@ -1,14 +1,14 @@
-# ai-rag-template
+# AI RAG Template
 
-The `ai-rag-template` is a template to build and run your own RAG application to have a Chatbot that is capable to perform a conversation with an user.
+The _AI RAG Template_ is a template to build and run your own RAG application and build a Chatbot that is capable to perform a conversation with a user.
 
-The service is developed using the [LangChain](https://python.langchain.com/docs/get_started/introduction/) framework, which enables creating sequences of complex interactions using Large Language Models. The web server was implemented using the [FastAPI](https://fastapi.tiangolo.com/) framework.
+The service is developed using the [LangChain](https://python.langchain.com/docs/get_started/introduction/) framework, which enables creating sequences of complex interactions using Large Language Models. The web server is implemented using the [FastAPI](https://fastapi.tiangolo.com/) framework.
 
 In order to work, it is required to have a MongoDB instance to be used as Vector Store and that supports [MongoDB Vector Search indexes](https://www.mongodb.com/docs/atlas/atlas-vector-search/tutorials/vector-search-quick-start/), which means an Atlas instance with version 6 or above.
 
 ## Overview
 
-The following is the high-level architecture of _ai-rag-template_.
+The following is the high-level architecture of the template.
 
 ```mermaid
 flowchart LR
@@ -30,7 +30,7 @@ flowchart LR
 
 ### Embeddings
 
-Please mind that the _ai-rag-template_ does not include embeddings or any logic to create them. It is intended that the Vector Store will include the embeddings (or these are generated separately). In any case, please ensure that the embedding model used the populate the Vector Store is the same embedding model used when running the service, otherwise the service will generate answers only based on its own knowledge, without being able to use the Vector Store, with the risk of hallucinations when chatting with the user.
+Please mind that the template does not include embeddings or any logic to create them. It is intended that the Vector Store will include the embeddings (or these are generated separately). In any case, please ensure that the embedding model used the populate the Vector Store is the same embedding model used when running the service, otherwise the service will generate answers only based on its own knowledge, without being able to use the Vector Store, with the risk of hallucinations when chatting with the user.
 
 ### API
 
@@ -84,7 +84,7 @@ curl 'http://localhost:3000/chat/completions' \
 
 ### Metrics Endpoint (`/-/metrics`)
 
-The `/-/metrics` endpoint exposes the metrics collected by Prometheus.
+The `/-/metrics` endpoint exposes useful metrics to be collected by Prometheus.
 
 ## Environment Variables
 

--- a/docs/10_Overview_And_Usage.md
+++ b/docs/10_Overview_And_Usage.md
@@ -28,6 +28,10 @@ flowchart LR
   be --8. bot answer--> fe
 ```
 
+### Embeddings
+
+Please mind that the _ai-rag-template_ does not include embeddings or any logic to create them. It is intended that the Vector Store will include the embeddings (or these are generated separately). In any case, please ensure that the embedding model used the populate the Vector Store is the same embedding model used when running the service, otherwise the service will generate answers only based on its own knowledge, without being able to use the Vector Store, with the risk of hallucinations when chatting with the user.
+
 ### API
 
 When running the service, the application exposes a Swagger UI at the `/docs` endpoint.

--- a/docs/10_Overview_And_Usage.md
+++ b/docs/10_Overview_And_Usage.md
@@ -1,19 +1,97 @@
 # ai-rag-template
 
-The `ai-rag-template` is a template to build and run your own RAG application to have a Chatbot that is capable to perform a conversation with the user.
+The `ai-rag-template` is a template to build and run your own RAG application to have a Chatbot that is capable to perform a conversation with an user.
 
-<!-- TODO: We use OpenAI, Langchain, MongoDB -->
+The service is developed using the [LangChain](https://python.langchain.com/docs/get_started/introduction/) framework, which enables creating sequences of complex interactions using Large Language Models. The web server was implemented using the [FastAPI](https://fastapi.tiangolo.com/) framework.
+
+In order to work, it is required to have a MongoDB instance to be used as Vector Store and that supports [MongoDB Vector Search indexes](https://www.mongodb.com/docs/atlas/atlas-vector-search/tutorials/vector-search-quick-start/), which means an Atlas instance with version 6 or above.
+
+## Overview
+
+The following is the high-level architecture of _ai-rag-template_.
+
+```mermaid
+flowchart LR
+  fe[Frontend]
+  be[Backend]
+  vs[(Vector Store)]
+  llm[LLM API]
+  eg[Embeddings Generator API]
+
+  fe --1. user question +\nchat history--> be
+  be --2. user question--> eg
+  eg --3. embedding-->be
+  be --4. similarity search-->vs
+  vs --5. similar docs-->be
+  be --6. user question +\nchat history +\nsimilar docs-->llm
+  llm --7. bot answer--> be
+  be --8. bot answer--> fe
+```
+
+### API
+
+When running the service, the application exposes a Swagger UI at the `/docs` endpoint.
+
+### Chat Endpoint (`/chat/completions`)
+
+The `/chat/completions` endpoint generates responses to user queries based on provided context and chat history. It leverages information from the configured Vector Store to formulate relevant responses, enhancing the conversational experience.
+
+***Example***:
+
+<details>
+<summary>Request</summary>
+
+```curl
+curl 'http://localhost:3000/chat/completions' \
+  -H 'content-type: application/json' \
+  --data-raw '{"chat_query":"Design a CRUD schema for an online store selling merchandise items","chat_history":[]}'
+```
+
+</details>
+
+<details>
+<summary>Response</summary>
+
+```json
+{
+    "message": "For an online store selling merchandise items, we can design a CRUD schema for a `Product` entity with the following properties:\n\n- `name`: A mandatory string.\n- `description`: An optional string.\n- `price`: A mandatory number.\n\nThe CRUD schema, excluding the default attributes, would look like this:\n\n```json\n[\n  {\n    \"name\": \"name\",\n    \"type\": \"string\",\n    \"required\": true,\n    \"nullable\": false,\n    \"encryptionEnabled\": false,\n    \"encryptionSearchable\": false,\n    \"sensitivityValue\": 0\n  },\n  {\n    \"name\": \"price\",\n    \"type\": \"number\",\n    \"required\": true,\n    \"nullable\": false,\n    \"encryptionEnabled\": false,\n    \"encryptionSearchable\": false,\n    \"sensitivityValue\": 0\n  },\n  {\n    \"name\": \"description\",\n    \"type\": \"string\",\n    \"required\": false,\n    \"nullable\": false,\n    \"encryptionEnabled\": false,\n    \"encryptionSearchable\": false,\n    \"sensitivityValue\": 0\n  }\n]\n```\n\nThis schema defines the structure of the `Product` entity with the necessary properties for managing merchandise items in the online store.",
+    "references": [
+        {
+            "content": "### Create CRUD to Read and Write Table Data  \nTo evaluate the new page, it's essential to create a CRUD microservice and expose the relevant data through an endpoint, facilitating reading and writing operations on our table.  \n:::warning\nIf you're unfamiliar with CRUD microservices, consider consulting the [CRUD Tutorial](/console/tutorials/configure-marketplace-components/rest-api-for-crud-on-data.mdx).\n:::  \nFor our example, let's employ a basic CRUD microservice featuring a `Product` entity endowed with the subsequent properties:\n* `name`: A mandatory string.\n* `description`: An optional string.\n* `price`: A mandatory number.  \nThe data CRUD will be exposed via an endpoint named `products`.  \nBelow is the CRUD schema, excluding the default CRUD attributes (_id, creatorId, createdAt, updaterId, updatedAt, and \\_\\_STATE\\_\\_):  \n```json\n[\n{\n\"name\":\"name\",\n\"type\":\"string\",\n\"required\":true,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n},\n{\n\"name\":\"price\",\n\"type\":\"number\",\n\"required\":true,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n},\n{\n\"name\":\"description\",\n\"type\":\"string\",\n\"required\":false,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n}\n]\n```\nNow, the CRUD data can be exposed using an endpoint named `products`.",
+            "url": "https://docs.mia-platform.eu/docs/microfrontend-composer/tutorials/basics"
+        },
+        {
+            "content": "### Create CRUD to Read and Write Table Data  \nTo evaluate the new page, it's essential to create a CRUD microservice and expose the relevant data through an endpoint, facilitating reading and writing operations on our table.  \n:::warning\nIf you're unfamiliar with CRUD microservices, consider consulting the [CRUD Tutorial](/console/tutorials/configure-marketplace-components/rest-api-for-crud-on-data.mdx).\n:::  \nFor our example, let's employ a basic CRUD microservice featuring a `Product` entity endowed with the subsequent properties:\n* `name`: A mandatory string.\n* `description`: An optional string.\n* `price`: A mandatory number.  \nThe data CRUD will be exposed via an endpoint named `products`.  \nBelow is the CRUD schema, excluding the default CRUD attributes (_id, creatorId, createdAt, updaterId, updatedAt, and \\_\\_STATE\\_\\_):  \n```json\n[\n{\n\"name\":\"name\",\n\"type\":\"string\",\n\"required\":true,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n},\n{\n\"name\":\"price\",\n\"type\":\"number\",\n\"required\":true,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n},\n{\n\"name\":\"description\",\n\"type\":\"string\",\n\"required\":false,\n\"nullable\":false,\n\"encryptionEnabled\":false,\n\"encryptionSearchable\":false,\n\"sensitivityValue\":0\n}\n]\n```\nNow, the CRUD data can be exposed using an endpoint named `products`.",
+            "url": "https://docs.mia-platform.eu/docs/microfrontend-composer/tutorials/basics"
+        },
+        {
+            "content": "### Create a CRUD for persistency  \nTo create a CRUD service you can follow [this](/console/tutorials/configure-marketplace-components/rest-api-for-crud-on-data.mdx) tutorial.\nAs data schema please import this <a download target=\"_blank\" href=\"/docs_files_to_download/flow-manager-service/saga-collection.json\">schema</a>.  \nRemember to create a **unique index** for the collection on the `sagaId` field and to set the **default state** for new documents to `PUBLIC`.  \nTo do this follow these steps:\n1. Open the _Design_ section of the Console.\n1. On the left panel, in the _Data Models_ group, click on _MongoDB CRUD_ section.\n1. Click on the CRUD you created.\n1. In the _Indexes_ section click _Add index_.\n1. Enter these values:\n- **Name**: `sagaIdIndex`\n- **Type**: `Normal`\n- **Field**: `sagaId`  \n<div style={{display: 'flex', justifyContent: 'center'}}>\n<div style={{display: 'flex', width: '600px'}}>  \n![Create CRUD index](img/create-crud-1.png)  \n</div>\n</div>  \n1. Click _Create_. The new index will be shown.\n1. Set the `unique` checkbox for the `sagaIdIndex` index.\n1. In the _Internal Endpoints_ section make sure that `Default state` is set to `PUBLIC`.  \n<div style={{display: 'flex', justifyContent: 'center'}}>\n<div style={{display: 'flex', width: '600px'}}>  \n![Create CRUD index](img/create-crud-2.png)  \n</div>\n</div>  \nYou can find more information on CRUD Persistency Manager in the [dedicated](/runtime_suite/flow-manager-service/30_configuration.md#crud-persistency-manager) page.",
+            "url": "https://docs.mia-platform.eu/docs/console/tutorials/configure-marketplace-components/flow-manager"
+        },
+        {
+            "content": "### Create a CRUD for persistency  \nTo create a CRUD service you can follow [this](/console/tutorials/configure-marketplace-components/rest-api-for-crud-on-data.mdx) tutorial.\nAs data schema please import this <a download target=\"_blank\" href=\"/docs_files_to_download/flow-manager-service/saga-collection.json\">schema</a>.  \nRemember to create a **unique index** for the collection on the `sagaId` field and to set the **default state** for new documents to `PUBLIC`.  \nTo do this follow these steps:\n1. Open the _Design_ section of the Console.\n1. On the left panel, in the _Data Models_ group, click on _MongoDB CRUD_ section.\n1. Click on the CRUD you created.\n1. In the _Indexes_ section click _Add index_.\n1. Enter these values:\n- **Name**: `sagaIdIndex`\n- **Type**: `Normal`\n- **Field**: `sagaId`  \n<div style={{display: 'flex', justifyContent: 'center'}}>\n<div style={{display: 'flex', width: '600px'}}>  \n![Create CRUD index](img/create-crud-1.png)  \n</div>\n</div>  \n1. Click _Create_. The new index will be shown.\n1. Set the `unique` checkbox for the `sagaIdIndex` index.\n1. In the _Internal Endpoints_ section make sure that `Default state` is set to `PUBLIC`.  \n<div style={{display: 'flex', justifyContent: 'center'}}>\n<div style={{display: 'flex', width: '600px'}}>  \n![Create CRUD index](img/create-crud-2.png)  \n</div>\n</div>  \nYou can find more information on CRUD Persistency Manager in the [dedicated](/runtime_suite/flow-manager-service/30_configuration.md#crud-persistency-manager) page.",
+            "url": "https://docs.mia-platform.eu/docs/console/tutorials/configure-marketplace-components/flow-manager"
+        }
+    ]
+}
+```
+
+</details>
+
+### Metrics Endpoint (`/-/metrics`)
+
+The `/-/metrics` endpoint exposes the metrics collected by Prometheus.
 
 ## Environment Variables
 
 The following environment variables are required for the service to work:
 
-- **PORT**: the port used to expose the API (default: *3000*)
-- **LOG_LEVEL**: the level of the logger (default: *INFO*)
+- **PORT**: the port used to expose the API (default: _3000_)
+- **LOG_LEVEL**: the level of the logger (default: _INFO_)
 - **CONFIGURATION_PATH**: the path that contains the [JSON configuration file](#configuration)
 - **MONGODB_CLUSTER_URI**: the MongoDB connectio string
-- **LLM_API_KEY**: the API Key of the LLM (*NOTE*: currently, we support only the OpenAI models, thus the API Key is the same as the OpenAI API Key)
-- **EMBEDDINGS_API_KEY**: the API Key of the embeddings model (*NOTE*: currently, we support only the OpenAI models, thus the API Key is the same as the OpenAI API Key)
+- **LLM_API_KEY**: the API Key of the LLM (_NOTE_: currently, we support only the OpenAI models, thus the API Key is the same as the OpenAI API Key)
+- **EMBEDDINGS_API_KEY**: the API Key of the embeddings model (_NOTE_: currently, we support only the OpenAI models, thus the API Key is the same as the OpenAI API Key)
 
 It is suggested to save the environment variables in a `.env` file.
 
@@ -59,9 +137,9 @@ Description of configuration parameters:
 | Embeddings Name | `embeddings.name` | Name of the encoder to use. We currently support only [OpenAI embeddings models](https://platform.openai.com/docs/guides/embeddings/what-are-embeddings). |
 | Vector Store DB Name | `vectorStore.dbName` | Name of the MongoDB database to use as a knowledge base and that contains the collection with the embeddings. |
 | Vector Store Collection Name | `vectorStore.collectionName` | Name of the MongoDB collection to use for storing documents and document embeddings. |
-| Vector Store Index Name | `vectorStore.indexName` | Name of the vector index to use for retrieving documents related to the user's query. **Note:** [Currently, it's necessary to manually create this index on MongoDB Atlas.](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/) |
-| Vector Store Relevance Score Function | `vectorStore.relevanceScoreFn` | Name of the similarity function used for extracting similar documents using the created vector index. **Note:** Must be the same used to create the vector index. |
-| Vector Store Embeddings Key | `vectorStore.embeddingsKey` | Name of the field used to save the semantic encoding of documents. The question received will be compared to the vector in this field with the Vector Index. |
+| Vector Store Index Name | `vectorStore.indexName` | Name of the vector index to use for retrieving documents related to the user's query. For more info, refer to the [Create a Vector index](#create-a-vector-index) paragraph. |
+| Vector Store Relevance Score Function | `vectorStore.relevanceScoreFn` | Name of the similarity function used for extracting similar documents using the created vector index. For more info, refer to the [Create a Vector index](#create-a-vector-index) paragraph. |
+| Vector Store Embeddings Key | `vectorStore.embeddingsKey` | Name of the field used to save the semantic encoding of documents. The question received will be compared to the vector in this field with the Vector Index. For more info, refer to the [Create a Vector index](#create-a-vector-index) paragraph. |
 | Vector Store Text Key | `vectorStore.textKey` | Name of the field used to save the raw document (or chunk of document). The content of this field will be included in the prompt. |
 | Vector Store Max. Documents To Retrieve | `vectorStore.maxDocumentsToRetrieve` | Maximum number of documents retrieved from the Vector Store. |
 | Vector Store Min. Score Distance | `vectorStore.minScoreDistance` | Minimum score required for the extracted document to be used in the prompt. Any document with a score below this value will be discarded. |
@@ -70,7 +148,7 @@ Description of configuration parameters:
 
 ### Create a Vector Index
 
-This template requires a [MongoDB Vector Search Index](https://www.mongodb.com/docs/atlas/atlas-vector-search/tutorials/vector-search-quick-start/) to function correctly, and requires a MongoDB Atlas instance version 6 or above to work.
+This template requires a [MongoDB Vector Search Index](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/) to function correctly, and requires a MongoDB Atlas instance version 6 or above to work.
 
 You can create a new Vector Search Index with the following structure:
 
@@ -92,5 +170,3 @@ You should remember to:
 - to have as `path` the same value of the `vectorStore.embeddingsKey` configuration parameter
 - to have as `similarity` the same value of the `vectorStore.relevanceScoreFn` configuration parameter
 - to have as `numDimensions` to appropriate value based on the [embeddings model used](https://platform.openai.com/docs/guides/embeddings/how-to-get-embeddings)
-
-## API

--- a/src/app.py
+++ b/src/app.py
@@ -18,8 +18,9 @@ from src.infrastracture.metrics.manager import MetricsManager
 def create_app(context: AppContext) -> FastAPI:
     app = FastAPI(
         openapi_url="/documentation/json",
-        # docs_url=None,
-        redoc_url=None
+        redoc_url=None,
+        title="ai-rag-template",
+        version="0.1.1"
     )
 
     app.add_middleware(AppContextMiddleware, app_context=context)

--- a/src/configurations/service_config.json
+++ b/src/configurations/service_config.json
@@ -142,7 +142,6 @@
   "required": [
     "llm",
     "embeddings",
-    "vectorStore",
-    "documentation"
+    "vectorStore"
   ]
 }

--- a/tests/fixtures/app_context.py
+++ b/tests/fixtures/app_context.py
@@ -32,19 +32,6 @@ def app_context():
             "relevanceScoreFn": "euclidean",
             "embeddingKey": "embedding",
             "textKey": "page_content"
-        },
-        documentation={
-            "repository": {
-                "baseUrl": "https://api.github.com/repos",
-                "owner": "mia-platform",
-                "name": "documentation",
-                "baseDir": "docs",
-                "supportedExtensions": [".md", ".mdx"],
-                "requestTimeoutInSeconds": 10
-            },
-            "website": {
-                "baseUrl": "https://docs.mia-platform.eu",
-            }
         }
     )
 


### PR DESCRIPTION
The following Pull Request includes some updates to the documentation:

- the information to document how to service works and what are the env vars and the configuration files to used are moved inside the _10_Overview_And_Usage_ file. The _README.md_ is therefore shortened and refer to it;

Also: 

- Fixed an error on the service_config.json with an error regarding a property defined as required but not included in the JSON Schema;
- Removed references in tests and default files about the `documentation` property and the `chatHistory` property (since does not exists);
- Add the name and version of the template in the Swagger interface.