### PR TITLE
feat: Automatic creation/update of the Vector Index

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.12.3'
         cache: 'pip'
     - run: pip install -r requirements.txt
     - run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__
 *.configuration.json
 !default.configuration.json
 !tests/**/*.configuration.json
+
+# Visual Studio Code configurations
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Automatic creation/update of the Vector Index
+
 ## 0.2.0 - 2024-08-21
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -113,9 +113,7 @@ The values `numDimensions`, `embeddingKey` and `relevanceScoreFn` comes from the
 
 > **NOTE**
 >
-> In order to create a Vector Index, you need a MongoDB Atlas instance, otherwise the RAG retrieval mechanism will not work.
->
-> In case your Atlas instance is a cluster M5 or below, the automatic generation will fail: a warning will appear in the logs just after the startup and the service will run normally, but you will be required to create/update the Vector Index manually.
+> In the event that an error occurs during the creation or update of the Vector Index, the exception will be logged, but the application will still start. However, the functioning of the service is not guaranteed.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,33 @@ flowchart LR
   be --8. bot answer--> fe
 ```
 
+## Vector Index
+
+The application will check if the collection includes at Vector Search Index at startup. If it does not find it, it will create a new one. If there's already one, it will try to update if notices that there any difference between the existing one and the one based on the values included in the [configuration](#configuration) file.
+
+The Vector Search Index will have the following structure:
+
+```json
+{
+  "fields": [
+    {
+      "numDimensions": <numDimensions>,
+      "path": "<embeddingKey>",
+      "similarity": "<relevanceScoreFn>",
+      "type": "vector"
+    }
+  ]
+}
+```
+
+The values `numDimensions`, `embeddingKey` and `relevanceScoreFn` comes from the [configuration file](#configuration). While `embeddingKey` and `relevanceScoreFn` comes exactly from the values included in the file, the `numDimensions` depends on the Embedding Model used (supported: `text-embedding-3-small` and `text-embedding-3-large`).
+
+> **NOTE**
+>
+> In order to create a Vector Index, you need a MongoDB Atlas instance, otherwise the RAG retrieval mechanism will not work.
+>
+> In case your Atlas instance is a cluster M5 or below, the automatic generation will fail: a warning will appear in the logs just after the startup and the service will run normally, but you will be required to create/update the Vector Index manually.
+
 ## Configuration
 
 The service requires several configuration parameters for execution. Below is an example configuration:
@@ -148,9 +175,9 @@ Description of configuration parameters:
 | Embeddings Name | Name of the encoder to use. [Must be supported by LangChain.](https://python.langchain.com/docs/integrations/text_embedding/) |
 | Vector Store DB Name | Name of the MongoDB database to use as a knowledge base. |
 | Vector Store Collection Name | Name of the MongoDB collection to use for storing documents and document embeddings. |
-| Vector Store Index Name | Name of the vector index to use for retrieving documents related to the user's query. **Note:** [Currently, it's necessary to manually create this index on MongoDB Atlas.](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/) |
-| Vector Store Relevance Score Function | Name of the similarity function used for extracting similar documents using the created vector index. **Note:** Must be the same used to create the vector index. |
-| Vector Store Embeddings Key | Name of the field used to save the semantic encoding of documents. |
+| Vector Store Index Name | Name of the vector index to use for retrieving documents related to the user's query. The application will check at startup if a vector index with this name exists, it needs to be updated or needs to be created. |
+| Vector Store Relevance Score Function | Name of the similarity function used for extracting similar documents using the created vector index. In case the existing vector index uses a different similarity function, the index will be updated using this as a similarity function. |
+| Vector Store Embeddings Key | Name of the field used to save the semantic encoding of documents. In case the existing vector index uses a different key to store the embedding in the collection, the index will be updated using this as key. Please mind that any change of this value might require to recreate the embeddings. |
 | Vector Store Text Key | Name of the field used to save the raw document (or chunk of document). |
 | Vector Store Max. Documents To Retrieve | Maximum number of documents to retrieve from the Vector Store. |
 | Vector Store Min. Score Distance | Minimum distance beyond which retrieved documents from the Vector Store are discarded. |
@@ -161,7 +188,7 @@ Description of configuration parameters:
 | Documentation Repository Request Timeout In Seconds | Time limit to download a single documentation file. |
 | Documentation Repository Supported Extensions | Name of supported file extensions (currently only Markdown files). |
 | Chain RAG System Prompts File Path | ath to the file containing system prompts for the RAG model. |
-| Chain RAG User Prompts File Path | Path to the file containing user prompts for the RAG model.
+| Chain RAG User Prompts File Path | Path to the file containing user prompts for the RAG model. |
 
 ## Local Development
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,6 +88,7 @@ PyYAML==6.0.1
 referencing==0.34.0
 regex==2023.12.25
 requests==2.32.0
+requests-mock==1.12.1
 responses==0.25.0
 respx==0.21.1
 rpds-py==0.18.0

--- a/src/app.py
+++ b/src/app.py
@@ -13,6 +13,7 @@ from src.configurations.variables import get_variables
 from src.context import AppContext, AppContextParams
 from src.infrastracture.logger import get_logger
 from src.infrastracture.metrics.manager import MetricsManager
+from src.lib.vector_search_index_updater import VectorSearchIndexUpdater
 
 
 def create_app(context: AppContext) -> FastAPI:
@@ -53,6 +54,9 @@ if __name__ == '__main__':
     )
 
     application = create_app(app_context)
+
+    vector_search_index_updater = VectorSearchIndexUpdater(app_context)
+    vector_search_index_updater.update_vector_search_index()
 
     uvicorn.run(
         application,

--- a/src/application/embeddings/embedding_generator.py
+++ b/src/application/embeddings/embedding_generator.py
@@ -131,7 +131,10 @@ class EmbeddingGenerator():
             self.logger.debug(f"Scraping page: {url}")  # for debugging and to see the progress
 
             # Get the text from the URL using BeautifulSoup
-            soup = BeautifulSoup(requests.get(url, timeout=5).text, "html.parser")
+            response = requests.get(url, timeout=5)
+            response.raise_for_status()
+
+            soup = BeautifulSoup(response.text, "html.parser")
 
             # Get the text but remove the tags
             text = soup.get_text()

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,10 @@
+from typing import Dict
+
+# Constants related to the vector index
+VECTOR_INDEX_TYPE = "vectorSearch"
+DEFAULT_NUM_DIMENSIONS_VALUE = 1536
+
+DIMENSIONS_DICT: Dict[str, int] = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+}

--- a/src/lib/vector_search_index_updater.py
+++ b/src/lib/vector_search_index_updater.py
@@ -1,0 +1,100 @@
+from logging import Logger
+
+from pymongo import MongoClient
+from pymongo.collection import Collection
+from pymongo.operations import SearchIndexModel
+
+from src.configurations.service_model import RelevanceScoreFn
+from src.constants import DEFAULT_NUM_DIMENSIONS_VALUE, DIMENSIONS_DICT, VECTOR_INDEX_TYPE
+from src.context import AppContext
+
+
+class VectorSearchIndexUpdater:
+    def __init__(self, app_context: AppContext):
+        self.app_context: AppContext = app_context
+        self.logger: Logger = app_context.logger
+        self.embedding_key = app_context.configurations.vectorStore.embeddingKey
+        self.index_name = app_context.configurations.vectorStore.indexName
+
+        self.collection: Collection = None
+        self._init_collection()
+
+    def _init_collection(self) -> None:
+        mongo_cluster_uri = self.app_context.env_vars.MONGODB_CLUSTER_URI
+        db_name = self.app_context.configurations.vectorStore.dbName
+        collection_name = self.app_context.configurations.vectorStore.collectionName
+
+        try:
+            client = MongoClient(mongo_cluster_uri)
+            db = client.get_database()
+            self.collection = db[collection_name]
+        except Exception:
+            self.collection = client[db_name][collection_name]
+
+    def _create_vector_index(self, new_index_definition: SearchIndexModel) -> None:
+        self.logger.info(f'Vector Search index "{self.index_name}" missing, it will be created now')
+        self.logger.debug(f'Creating Vector Search index to the following definition: "{new_index_definition.document.get("definition")}"')
+        self.collection.create_search_index(model=new_index_definition)
+        self.logger.info(f'Created Vector Search index "{self.index_name}"')
+
+
+    def _update_vector_index(self, current_index_definition: SearchIndexModel, new_index_definition: SearchIndexModel):
+        self.logger.info(f'Check of MongoDB Vector Search index "{self.index_name}"')
+
+        current_fields = current_index_definition.document.get("definition")
+        new_fields = new_index_definition.document.get("definition")
+
+        if current_fields == new_fields:
+            self.logger.info("Vector Search index is up-to-date, no further action required")
+            return
+
+        self.logger.debug(f'Updating Vector Search index to the following definition: "{new_fields.get("fields")}"')
+        self.collection.update_search_index(self.index_name, new_fields)
+        self.logger.info(f'Updated Vector Search index "{self.index_name}"')
+
+
+    def _get_current_vector_index_definition(self) -> SearchIndexModel | None:
+        indexes = self.collection.list_search_indexes()
+
+        vector_index = next((index for index in indexes if index["name"] == self.index_name), None)
+
+        if vector_index is None:
+            return None
+
+        return SearchIndexModel(definition=vector_index.get("latestDefinition"), name=vector_index.get("name"), type="vectorSearch")
+
+
+    def _get_updated_vector_index_definition(self) -> SearchIndexModel:
+        configured_similarity_fn = self.app_context.configurations.vectorStore.relevanceScoreFn or RelevanceScoreFn.cosine
+        num_dimensions = DIMENSIONS_DICT.get(self.app_context.configurations.embeddings.name, DEFAULT_NUM_DIMENSIONS_VALUE)
+
+        return SearchIndexModel(
+            definition={
+                "fields": [
+                    {
+                        "numDimensions": num_dimensions, 
+                        "path": self.embedding_key, 
+                        "similarity": configured_similarity_fn.value, 
+                        "type": "vector"
+                    }
+                ]
+            },
+            name=self.index_name,
+            type=VECTOR_INDEX_TYPE,
+        )
+
+
+    def update_vector_search_index(self) -> None:
+        try:
+            current_vector_index_definition = self._get_current_vector_index_definition()
+            new_vector_index_definition = self._get_updated_vector_index_definition()
+
+            if current_vector_index_definition is None:
+                self._create_vector_index(new_vector_index_definition)
+            else:
+                self._update_vector_index(current_vector_index_definition, new_vector_index_definition)
+        except Exception as ex:
+            self.logger.warn(f'Unable to update Vector Search index "{self.index_name}".')
+            self.logger.warn(ex)
+            self.logger.warn("Service will continue to run, but you might experience unwanted behaviors.")
+

--- a/src/lib/vector_search_index_updater.py
+++ b/src/lib/vector_search_index_updater.py
@@ -28,6 +28,7 @@ class VectorSearchIndexUpdater:
             client = MongoClient(mongo_cluster_uri)
             db = client.get_database()
             self.collection = db[collection_name]
+        # pylint: disable=broad-except
         except Exception:
             self.collection = client[db_name][collection_name]
 
@@ -93,8 +94,8 @@ class VectorSearchIndexUpdater:
                 self._create_vector_index(new_vector_index_definition)
             else:
                 self._update_vector_index(current_vector_index_definition, new_vector_index_definition)
+        # pylint: disable=broad-except
         except Exception as ex:
             self.logger.warn(f'Unable to update Vector Search index "{self.index_name}".')
             self.logger.warn(ex)
             self.logger.warn("Service will continue to run, but you might experience unwanted behaviors.")
-

--- a/tests/src/application/embeddings/embedding_generator_test.py
+++ b/tests/src/application/embeddings/embedding_generator_test.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 from unittest.mock import patch
+
+import requests
 import requests_mock
 
 from src.application.embeddings.embedding_generator import EmbeddingGenerator
+
 
 def test_generate(app_context):
     current_dir = Path(__file__).parent
@@ -10,15 +13,18 @@ def test_generate(app_context):
     with open(file_path, 'r', encoding='utf-8') as f:
         html_content = f.read()
 
-    with requests_mock.Mocker() as mock_requests, \
-        patch("langchain_experimental.text_splitter.SemanticChunker.split_text") as mock_split_text, \
+    # Initializing mock
+    session = requests.Session()
+    adapter = requests_mock.Adapter()
+
+    session.mount('http://', adapter)
+    adapter.register_uri('GET', 'http://example.com', text=html_content)
+
+    with patch("langchain_experimental.text_splitter.SemanticChunker.split_text") as mock_split_text, \
         patch('langchain_community.vectorstores.mongodb_atlas.MongoDBAtlasVectorSearch.add_documents') as mock_add_documents:
-
-        embedding_generator = EmbeddingGenerator(app_context)
-
-        mock_requests.get("http://example.com", text=html_content)
         mock_split_text.return_value = ["chunk1", "chunk2"]
 
+        embedding_generator = EmbeddingGenerator(app_context)
         embedding_generator.generate("http://example.com")
 
         mock_split_text.assert_called_once()

--- a/tests/src/application/embeddings/embedding_generator_test.py
+++ b/tests/src/application/embeddings/embedding_generator_test.py
@@ -10,7 +10,7 @@ def test_generate(app_context):
     with open(file_path, 'r', encoding='utf-8') as f:
         html_content = f.read()
 
-    with patch('requests.api.get') as mock_requests_get, \
+    with patch('requests.get') as mock_requests_get, \
         patch("langchain_experimental.text_splitter.SemanticChunker.split_text") as mock_split_text, \
         patch('langchain_community.vectorstores.mongodb_atlas.MongoDBAtlasVectorSearch.add_documents') as mock_add_documents:
 

--- a/tests/src/application/embeddings/embedding_generator_test.py
+++ b/tests/src/application/embeddings/embedding_generator_test.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from unittest.mock import patch
+import requests_mock
 
 from src.application.embeddings.embedding_generator import EmbeddingGenerator
-
 
 def test_generate(app_context):
     current_dir = Path(__file__).parent
@@ -10,13 +10,13 @@ def test_generate(app_context):
     with open(file_path, 'r', encoding='utf-8') as f:
         html_content = f.read()
 
-    with patch('requests.get') as mock_requests_get, \
+    with requests_mock.Mocker() as mock_requests, \
         patch("langchain_experimental.text_splitter.SemanticChunker.split_text") as mock_split_text, \
         patch('langchain_community.vectorstores.mongodb_atlas.MongoDBAtlasVectorSearch.add_documents') as mock_add_documents:
 
         embedding_generator = EmbeddingGenerator(app_context)
 
-        mock_requests_get.return_value.text = html_content
+        mock_requests.get("http://example.com", text=html_content)
         mock_split_text.return_value = ["chunk1", "chunk2"]
 
         embedding_generator.generate("http://example.com")

--- a/tests/src/lib/vector_search_index_updater_test.py
+++ b/tests/src/lib/vector_search_index_updater_test.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock, call, patch
+
+from src.lib.vector_search_index_updater import VectorSearchIndexUpdater
+
+
+def test_update_vector_index_requires_no_changes(app_context):
+    '''
+    app_context (from `/tests/fixtures/app_context.py`) includes:
+    - vectorStore.indexName = "openai_vector_index"
+    - vectorStore.relevanceScoreFn = "euclidean" (which means that the index must have "similarity" equal to "euclidean")
+    - embeddings.name = "text-emebedding-3-small" (which means that the index must have "numDimensions" equal to 1536)
+
+    The mock should not receive instruction to update the index "openai_vector_index" since there won't be any changes on its definition.
+    '''
+    with (
+        patch("pymongo.collection.Collection") as mock_collection,
+        patch("pymongo.MongoClient.__new__") as mock_client,
+    ):
+        mock_client.return_value = {"sample_mflix": {"movies": mock_collection}}
+
+        mock_collection.list_search_indexes.return_value = [
+            {"name": "another_vector_index", "latestDefinition": {"fields": []}},
+            {
+                "name": "openai_vector_index",
+                "latestDefinition": {
+                    "fields": [
+                        {"numDimensions": 1536, "path": "embedding", "similarity": "euclidean", "type": "vector"}
+                    ]
+                },
+            },
+        ]
+
+        vector_search_index_updater = VectorSearchIndexUpdater(app_context)
+        vector_search_index_updater.update_vector_search_index()
+
+        mock_collection.list_search_indexes.assert_called_once()
+        mock_collection.create_search_index.assert_not_called()
+        mock_collection.update_search_index.assert_not_called()
+
+        info_log_calls = [
+            call('Check of MongoDB Vector Search index "openai_vector_index"'),
+            call("Vector Search index is up-to-date, no further action required"),
+        ]
+        app_context.logger.info.assert_has_calls(info_log_calls, any_order=True)
+        app_context.logger.warn.assert_not_called()
+
+
+def test_update_vector_index_requires_create(app_context):
+    """
+    Since there's no vector index in the collection named "openai_vector_index", the mock should receive instruction to create the index.
+    """
+    with patch("pymongo.collection.Collection") as mock_collection, patch("pymongo.MongoClient.__new__") as mock_client:
+        mock_client.return_value = {"sample_mflix": {"movies": mock_collection}}
+        mock_collection.list_search_indexes.return_value = []
+        mock_collection.create_search_index = MagicMock()
+
+        vector_search_index_updater = VectorSearchIndexUpdater(app_context)
+        vector_search_index_updater.update_vector_search_index()
+
+        mock_collection.list_search_indexes.assert_called_once()
+        mock_collection.create_search_index.assert_called_once()
+        mock_collection.update_search_index.assert_not_called()
+
+        info_log_calls = [
+            call('Vector Search index "openai_vector_index" missing, it will be created now'),
+            call('Created Vector Search index "openai_vector_index"'),
+        ]
+        app_context.logger.info.assert_has_calls(info_log_calls, any_order=True)
+
+
+def test_update_vector_index_requires_update(app_context):
+    '''
+    app_context (from `/tests/fixtures/app_context.py`) includes:
+    - vectorStore.indexName = "openai_vector_index"
+    - vectorStore.relevanceScoreFn = "euclidean" (which means that the index must have "similarity" equal to "euclidean")
+    - embeddings.name = "text-emebedding-3-small" (which means that the index must have "numDimensions" equal to 1536)
+
+    The mock should receive instruction to update the index named "openai_vector_index" since both "similarity" and "numDimensions" must be updated.
+    '''
+    with patch("pymongo.collection.Collection") as mock_collection, patch("pymongo.MongoClient.__new__") as mock_client:
+        mock_client.return_value = {"sample_mflix": {"movies": mock_collection}}
+
+        mock_collection.list_search_indexes.return_value = [
+            {
+                "name": "openai_vector_index",
+                "latestDefinition": {
+                    "fields": [{"numDimensions": 3072, "path": "embedding", "similarity": "cosine", "type": "vector"}, {"path": "__STATE__", "type": "filter"}]
+                },
+            }
+        ]
+
+        vector_search_index_updater = VectorSearchIndexUpdater(app_context)
+        vector_search_index_updater.update_vector_search_index()
+
+        mock_collection.list_search_indexes.assert_called_once()
+        mock_collection.create_search_index.assert_not_called()
+        mock_collection.update_search_index.assert_called_once()
+
+        info_log_calls = [
+            call('Check of MongoDB Vector Search index "openai_vector_index"'),
+            call('Updated Vector Search index "openai_vector_index"'),
+        ]
+        app_context.logger.info.assert_has_calls(info_log_calls, any_order=True)


### PR DESCRIPTION
The Vector Search index is automatically updated in case of similarity function different than the configured `relevanceScoreFn' or a different `embeddingKey`.

In case the update fails (possible if running in MongoDB Atlas instances M5 or below), warnings are logged and the service starts anyway.