### PR TITLE
fix: restoring host to expose service

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -62,6 +62,7 @@ if __name__ == '__main__':
 
     uvicorn.run(
         application,
+        host='0.0.0.0', # nosec B104 # binding to all interfaces is required to expose the service in containers
         port=int(app_context.env_vars.PORT),
         log_level='error'
     )


### PR DESCRIPTION
The `host` property from `uvicorn.run` was removed to solve a bandit issue.

It has been restored otherwise the service won't be exposed.

Includes a `nosec` exception on that line.